### PR TITLE
Update flutter_quill version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: ^2.0.0
   charcode: ^1.2.0
   collection: ^1.15.0
-  flutter_quill: ^2.0.0
+  flutter_quill: ^3.2.0
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
This PR updates the `flutter_quill` dependency to the latest version so that this version can be used in a project that used `delta_markdown`.