### PR TITLE
Dependency Updates

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -70,7 +70,6 @@ linter:
     - file_names
     - hash_and_equals
     - implementation_imports
-    - invariant_booleans
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_names
@@ -103,7 +102,6 @@ linter:
     - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
-    - prefer_equal_for_default_values
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,5 @@
-include: package:pedantic/analysis_options.yaml
+include: package:flutter_lints/flutter.yaml
 analyzer:
-  strong-mode:
-    implicit-casts: false
   errors:
     dead_code: error
     unused_element: error
@@ -15,7 +13,6 @@ linter:
     # - always_put_required_named_parameters_first
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    - always_require_non_null_named_parameters
     - annotate_overrides
     - avoid_annotating_with_dynamic
     # - avoid_as
@@ -40,8 +37,6 @@ linter:
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     - avoid_returning_this
     # - avoid_setters_without_getters
@@ -76,13 +71,11 @@ linter:
     - hash_and_equals
     - implementation_imports
     - invariant_booleans
-    - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
     # - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list

--- a/lib/src/delta_markdown_decoder.dart
+++ b/lib/src/delta_markdown_decoder.dart
@@ -2,7 +2,8 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter_quill/flutter_quill.dart'
-    show Attribute, AttributeScope, Delta, LinkAttribute;
+    show Attribute, AttributeScope, LinkAttribute;
+import 'package:flutter_quill/quill_delta.dart';
 
 import 'ast.dart' as ast;
 import 'document.dart';

--- a/lib/src/delta_markdown_decoder.dart
+++ b/lib/src/delta_markdown_decoder.dart
@@ -239,7 +239,7 @@ class _DeltaVisitor implements ast.NodeVisitor {
         final href = el.attributes['src'];
         return ImageAttribute(href);
       case 'hr':
-        return DividerAttribute();
+        return const DividerAttribute();
     }
 
     return null;
@@ -247,9 +247,14 @@ class _DeltaVisitor implements ast.NodeVisitor {
 }
 
 class ImageAttribute extends Attribute<String?> {
-  ImageAttribute(String? val) : super('image', AttributeScope.EMBEDS, val);
+  const ImageAttribute(String? val)
+      : super(
+          'image',
+          AttributeScope.embeds,
+          val,
+        );
 }
 
 class DividerAttribute extends Attribute<String?> {
-  DividerAttribute() : super('divider', AttributeScope.EMBEDS, 'hr');
+  const DividerAttribute() : super('divider', AttributeScope.embeds, 'hr');
 }

--- a/lib/src/delta_markdown_encoder.dart
+++ b/lib/src/delta_markdown_encoder.dart
@@ -2,7 +2,8 @@ import 'dart:convert';
 
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter_quill/flutter_quill.dart'
-    show Attribute, AttributeScope, BlockEmbed, Delta, DeltaIterator, Style;
+    show Attribute, AttributeScope, BlockEmbed, Style;
+import 'package:flutter_quill/quill_delta.dart';
 
 class DeltaMarkdownEncoder extends Converter<String, String> {
   static const _lineFeedAsciiCode = 0x0A;

--- a/lib/src/delta_markdown_encoder.dart
+++ b/lib/src/delta_markdown_encoder.dart
@@ -20,7 +20,7 @@ class DeltaMarkdownEncoder extends Converter<String, String> {
   String convert(String input) {
     markdownBuffer = StringBuffer();
     lineBuffer = StringBuffer();
-    currentInlineStyle = Style();
+    currentInlineStyle = const Style();
     currentBlockLines = <String>[];
 
     final inputJson = jsonDecode(input) as List<dynamic>?;
@@ -66,7 +66,7 @@ class DeltaMarkdownEncoder extends Converter<String, String> {
     for (final value
         in currentInlineStyle.attributes.values.toList().reversed) {
       // TODO(tillf): Is block correct?
-      if (value.scope == AttributeScope.BLOCK) {
+      if (value.scope == AttributeScope.block) {
         continue;
       }
       if (style.containsKey(value.key)) {
@@ -89,7 +89,7 @@ class DeltaMarkdownEncoder extends Converter<String, String> {
     // Now open any new styles.
     for (final attribute in style.attributes.values) {
       // TODO(tillf): Is block correct?
-      if (attribute.scope == AttributeScope.BLOCK) {
+      if (attribute.scope == AttributeScope.block) {
         continue;
       }
       if (currentInlineStyle.containsKey(attribute.key)) {
@@ -124,7 +124,7 @@ class DeltaMarkdownEncoder extends Converter<String, String> {
         final lineBlock = Style.fromJson(attributes)
             .attributes
             .values
-            .singleWhereOrNull((a) => a.scope == AttributeScope.BLOCK);
+            .singleWhereOrNull((a) => a.scope == AttributeScope.block);
 
         if (lineBlock == currentBlockStyle) {
           currentBlockLines.add(lineBuffer.toString());

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -399,8 +399,8 @@ class AutolinkExtensionSyntax extends InlineSyntax {
   }
 }
 
-class _DelimiterRun {
-  _DelimiterRun._(
+class DelimiterRun {
+  DelimiterRun._(
       {this.char,
       this.length,
       this.isLeftFlanking,
@@ -420,8 +420,7 @@ class _DelimiterRun {
   final bool? isFollowedByPunctuation;
 
   // ignore: prefer_constructors_over_static_methods
-  static _DelimiterRun? tryParse(
-      InlineParser parser, int runStart, int runEnd) {
+  static DelimiterRun? tryParse(InlineParser parser, int runStart, int runEnd) {
     bool leftFlanking,
         rightFlanking,
         precededByPunctuation,
@@ -466,7 +465,7 @@ class _DelimiterRun {
       return null;
     }
 
-    return _DelimiterRun._(
+    return DelimiterRun._(
         char: parser.charAt(runStart),
         length: runEnd - runStart + 1,
         isLeftFlanking: leftFlanking,
@@ -516,7 +515,7 @@ class TagSyntax extends InlineSyntax {
       return true;
     }
 
-    final delimiterRun = _DelimiterRun.tryParse(parser, matchStart, matchEnd);
+    final delimiterRun = DelimiterRun.tryParse(parser, matchStart, matchEnd);
     if (delimiterRun != null && delimiterRun.canOpen) {
       parser.openTag(TagState(parser.pos, matchEnd + 1, this, delimiterRun));
       return true;
@@ -531,7 +530,7 @@ class TagSyntax extends InlineSyntax {
     final matchStart = parser.pos;
     final matchEnd = parser.pos + runLength - 1;
     final openingRunLength = state.endPos - state.startPos;
-    final delimiterRun = _DelimiterRun.tryParse(parser, matchStart, matchEnd);
+    final delimiterRun = DelimiterRun.tryParse(parser, matchStart, matchEnd);
 
     if (openingRunLength == 1 && runLength == 1) {
       parser.addNode(Element('em', state.children));
@@ -579,7 +578,7 @@ class StrikethroughSyntax extends TagSyntax {
     final runLength = match.group(0)!.length;
     final matchStart = parser.pos;
     final matchEnd = parser.pos + runLength - 1;
-    final delimiterRun = _DelimiterRun.tryParse(parser, matchStart, matchEnd)!;
+    final delimiterRun = DelimiterRun.tryParse(parser, matchStart, matchEnd)!;
     if (!delimiterRun.isRightFlanking!) {
       return false;
     }
@@ -1170,7 +1169,7 @@ class TagState {
   /// The children of this node. Will be `null` for text nodes.
   final List<Node> children;
 
-  final _DelimiterRun? openingDelimiterRun;
+  final DelimiterRun? openingDelimiterRun;
 
   /// Attempts to close this tag by matching the current text against its end
   /// pattern.
@@ -1193,7 +1192,7 @@ class TagState {
     final closingMatchStart = parser.pos;
     final closingMatchEnd = parser.pos + runLength - 1;
     final closingDelimiterRun =
-        _DelimiterRun.tryParse(parser, closingMatchStart, closingMatchEnd);
+        DelimiterRun.tryParse(parser, closingMatchStart, closingMatchEnd);
     if (closingDelimiterRun != null && closingDelimiterRun.canClose) {
       // Emphasis rules #9 and #10:
       final oneRunOpensAndCloses =

--- a/lib/src/inline_parser.dart
+++ b/lib/src/inline_parser.dart
@@ -194,9 +194,7 @@ class LineBreakSyntax extends InlineSyntax {
 
 /// Matches stuff that should just be passed through as straight text.
 class TextSyntax extends InlineSyntax {
-  TextSyntax(String pattern, {String? sub})
-      : substitute = sub,
-        super(pattern);
+  TextSyntax(super.pattern, {String? sub}) : substitute = sub;
 
   final String? substitute;
 
@@ -493,9 +491,8 @@ class DelimiterRun {
 /// Matches syntax that has a pair of tags and becomes an element, like `*` for
 /// `<em>`. Allows nested tags.
 class TagSyntax extends InlineSyntax {
-  TagSyntax(String pattern, {String? end, this.requiresDelimiterRun = false})
-      : endPattern = RegExp((end != null) ? end : pattern, multiLine: true),
-        super(pattern);
+  TagSyntax(super.pattern, {String? end, this.requiresDelimiterRun = false})
+      : endPattern = RegExp((end != null) ? end : pattern, multiLine: true);
 
   final RegExp endPattern;
 
@@ -1047,8 +1044,7 @@ class LinkSyntax extends TagSyntax {
 /// Matches images like `![alternate text](url "optional title")` and
 /// `![alternate text][label]`.
 class ImageSyntax extends LinkSyntax {
-  ImageSyntax({Resolver? linkResolver})
-      : super(linkResolver: linkResolver, pattern: r'!\[');
+  ImageSyntax({super.linkResolver}) : super(pattern: r'!\[');
 
   @override
   Node _createNode(TagState state, String destination, String? title) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,17 +6,17 @@ description: A library for converting between Markdown and Delta of the
 homepage: https://github.com/friebetill/notus_markdown
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   args: ^2.4.2
   charcode: ^1.3.1
-  collection: ^1.17.2
-  flutter_quill: ^8.2.5
+  collection: ^1.18.0
+  flutter_quill: ^9.2.13
 
 dev_dependencies:
-  build_runner: ^2.4.6
+  build_runner: ^2.4.8
   flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
-  test: ^1.24.3
+  test: ^1.24.9

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  args: ^2.4.2
+  args: ^2.5.0
   charcode: ^1.3.1
   collection: ^1.18.0
-  flutter_quill: 9.2.14
+  flutter_quill: 9.3.11
 
 dev_dependencies:
-  build_runner: ^2.4.8
-  flutter_lints: ^3.0.1
+  build_runner: ^2.4.9
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
   test: ^1.24.9

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,11 @@ dependencies:
   args: ^2.5.0
   charcode: ^1.3.1
   collection: ^1.18.0
-  flutter_quill: 9.3.11
+  flutter_quill: ^10.4.5
 
 dev_dependencies:
-  build_runner: ^2.4.9
+  build_runner: ^2.4.11
   flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
-  test: ^1.24.9
+  test: ^1.25.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  args: ^2.0.0
-  charcode: ^1.2.0
-  collection: ^1.15.0
-  flutter_quill: ^7.0.0
+  args: ^2.4.2
+  charcode: ^1.3.1
+  collection: ^1.17.2
+  flutter_quill: ^8.2.5
 
 dev_dependencies:
-  build_runner: ^2.0.0
+  build_runner: ^2.4.6
+  flutter_lints: ^3.0.1
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.0
-  test: ^1.16.5
+  test: ^1.24.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   args: ^2.4.2
   charcode: ^1.3.1
   collection: ^1.18.0
-  flutter_quill: ^9.2.13
+  flutter_quill: 9.2.14
 
 dev_dependencies:
   build_runner: ^2.4.8


### PR DESCRIPTION
- Updates dependencies
- Updates syntax
- Use [flutter_lints](https://pub.dev/packages/flutter_lints) instead of [pedantic](https://pub.dev/packages/pedantic) since it is deprecated